### PR TITLE
[portfolio] Improve project card interactions

### DIFF
--- a/src/components/AllProjectsItem.tsx
+++ b/src/components/AllProjectsItem.tsx
@@ -1,505 +1,210 @@
-// // src/components/AllProjectsItem.tsx
-
-// import React, { useState } from 'react';
-// import { ProjectData } from '../data/projectData';
-// import { Link } from 'react-router-dom'; // For "Full Details" navigation
-
-// interface AllProjectsItemProps {
-//   project: ProjectData;
-// }
-
-// const AllProjectsItem: React.FC<AllProjectsItemProps> = ({ project }) => {
-//   const { id, title, shortDesc, longDesc, imageUrl } = project;
-//   const [isExpanded, setIsExpanded] = useState(false);
-
-//   const handleCardClick = () => {
-//     // Toggle expanded details
-//     setIsExpanded(!isExpanded);
-//   };
-
-//   return (
-//     <div
-//       onClick={handleCardClick}
-//       className="bg-white dark:bg-gray-800 rounded-lg shadow-md hover:shadow-lg transition-shadow transform hover:-translate-y-1 cursor-pointer flex flex-col"
-//     >
-//       {/* Image section - optional */}
-//       {imageUrl ? (
-//         <img
-//           src={imageUrl}
-//           alt={title}
-//           className="w-full h-40 object-cover rounded-t-lg"
-//         />
-//       ) : (
-//         // Placeholder if no image is provided
-//         <div className="w-full h-40 bg-gray-200 dark:bg-gray-700 flex items-center justify-center rounded-t-lg">
-//           <p className="text-gray-500 dark:text-gray-300">No Image</p>
-//         </div>
-//       )}
-
-//       {/* Content */}
-//       <div className="p-4 flex-1 flex flex-col">
-//         <h3 className="text-xl font-bold mb-2 text-gray-800 dark:text-gray-100">
-//           {title}
-//         </h3>
-//         <p className="text-gray-600 dark:text-gray-300 line-clamp-2">{shortDesc}</p>
-
-//         {/* Expanded area */}
-//         {isExpanded && longDesc && (
-//           <div className="mt-3">
-//             <hr className="border-gray-300 dark:border-gray-600 mb-3" />
-//             <p className="text-gray-700 dark:text-gray-300">{longDesc}</p>
-//           </div>
-//         )}
-
-//         {/* Full Details button */}
-//         {isExpanded && (
-//           <div className="mt-auto pt-3">
-//             <Link
-//               to={`/projects/${id}`}
-//               onClick={(e) => e.stopPropagation()} // prevent card click toggling
-//               className="inline-block bg-indigo-500 dark:bg-indigo-600 text-white px-4 py-2 rounded-md font-semibold hover:opacity-90 transition-opacity"
-//             >
-//               View Full Details
-//             </Link>
-//           </div>
-//         )}
-//       </div>
-//     </div>
-//   );
-// };
-
-// export default AllProjectsItem;
-
-//WORKING
-// import React, { useState } from 'react';
-
-// import { ProjectData } from '../data/projectData';
-// import { Link } from 'react-router-dom';
-
-// interface AllProjectsItemProps {
-//   project: ProjectData;
-// }
-
-// const AllProjectsItem: React.FC<AllProjectsItemProps> = ({ project }) => {
-//   const { id, title, shortDesc, longDesc, imageUrl } = project;
-//   const [isExpanded, setIsExpanded] = useState(false);
-
-//   const handleCardClick = () => {
-//     setIsExpanded(!isExpanded);
-//   };
-
-//   return (
-//     <div
-//       onClick={handleCardClick}
-//       className="
-//         bg-white dark:bg-gray-800
-//         rounded-lg
-//         shadow-card /* your custom shadow from tailwind.config.js if desired */
-//         hover:shadow-card-hover
-//         transition-shadow
-//         cursor-pointer
-//         flex flex-col
-//         group
-        
-//         /* Lift-up on hover using Tailwind transforms */
-//         transform transition-transform duration-200
-//         hover:-translate-y-1
-//       "
-//     >
-//       {/* Optional image / placeholder */}
-//       {imageUrl ? (
-//         <img
-//           src={imageUrl}
-//           alt={title}
-//           className="w-full h-40 object-cover rounded-t-lg"
-//         />
-//       ) : (
-//         <div className="w-full h-40 bg-gray-200 dark:bg-gray-700 flex items-center justify-center rounded-t-lg">
-//           <p className="text-gray-500 dark:text-gray-300">No Image</p>
-//         </div>
-//       )}
-
-//       {/* Content */}
-//       <div className="p-4 flex-1 flex flex-col">
-//         <h3
-//           className="
-//             text-xl font-bold mb-2
-//             text-gray-800 dark:text-gray-100
-//             group-hover:text-accent /* if you have an accent color */
-//             transition-colors
-//           "
-//         >
-//           {title}
-//         </h3>
-//         <p className="text-gray-600 dark:text-gray-300 line-clamp-2">
-//           {shortDesc}
-//         </p>
-
-//         {/* Expanded area */}
-//         {isExpanded && longDesc && (
-//           <div className="mt-3">
-//             <hr className="border-gray-300 dark:border-gray-600 mb-3" />
-//             <p className="text-gray-700 dark:text-gray-300">{longDesc}</p>
-//           </div>
-//         )}
-
-//         {/* Full Details button */}
-//         {isExpanded && (
-//           <div className="mt-auto pt-3">
-//             <Link
-//               to={`/projects/${id}`}
-//               onClick={(e) => e.stopPropagation()} // prevent toggling on click
-//               className="
-//                 inline-block
-//                 bg-indigo-500 dark:bg-indigo-600
-//                 text-white px-4 py-2 rounded-md
-//                 font-semibold hover:opacity-90 transition-opacity
-//               "
-//             >
-//               View Full Details
-//             </Link>
-//           </div>
-//         )}
-//       </div>
-//     </div>
-//   );
-// };
-
-// export default AllProjectsItem;
-
-
-// import React, { useState } from 'react';
-// import { ProjectData } from '../data/projectData';
-// import { Link } from 'react-router-dom';
-
-// interface AllProjectsItemProps {
-//   project: ProjectData;
-// }
-
-// const AllProjectsItem: React.FC<AllProjectsItemProps> = ({ project }) => {
-//   const { title, shortDesc, longDesc, imageUrl, repoLink } = project;
-//   const [isExpanded, setIsExpanded] = useState(false);
-
-//   const handleCardClick = () => {
-//     setIsExpanded(!isExpanded);
-//   };
-
-//   return (
-//     <div
-//       onClick={handleCardClick}
-//       className="
-//         bg-white dark:bg-gray-800
-//         rounded-lg
-//         shadow-card
-//         hover:shadow-card-hover
-//         transition-shadow
-//         cursor-pointer
-//         flex flex-col
-//         group
-//         transform transition-transform duration-200
-//         hover:-translate-y-1
-//       "
-//     >
-//       {/* Optional image / placeholder */}
-//       {imageUrl ? (
-//         <img
-//           src={imageUrl}
-//           alt={title}
-//           className="w-full h-40 object-cover rounded-t-lg"
-//         />
-//       ) : (
-//         <div className="w-full h-40 bg-gray-200 dark:bg-gray-700 flex items-center justify-center rounded-t-lg">
-//           <p className="text-gray-500 dark:text-gray-300">No Image</p>
-//         </div>
-//       )}
-
-//       {/* Content */}
-//       <div className="p-4 flex-1 flex flex-col">
-//         <h3
-//           className="
-//             text-xl font-bold mb-2
-//             text-gray-800 dark:text-gray-100
-//             group-hover:text-accent
-//             transition-colors
-//           "
-//         >
-//           {title}
-//         </h3>
-//         <p className="text-gray-600 dark:text-gray-300 line-clamp-2">
-//           {shortDesc}
-//         </p>
-
-//         {/* Expanded area */}
-//         {isExpanded && longDesc && (
-//           <div className="mt-3">
-//             <hr className="border-gray-300 dark:border-gray-600 mb-3" />
-//             <p className="text-gray-700 dark:text-gray-300">{longDesc}</p>
-//           </div>
-//         )}
-
-//         {/* Link to GitHub repo */}
-//         {isExpanded && repoLink && (
-//           <div className="mt-auto pt-3">
-//             <a
-//               href={repoLink}
-//               target="_blank"
-//               rel="noopener noreferrer"
-//               onClick={(e) => e.stopPropagation()} // prevent toggling on click
-//               className="
-//                 inline-block
-//                 bg-indigo-500 dark:bg-indigo-600
-//                 text-white px-4 py-2 rounded-md
-//                 font-semibold hover:opacity-90 transition-opacity
-//               "
-//             >
-//               View Full Details
-//             </a>
-//           </div>
-//         )}
-//         {isExpanded && !repoLink && (
-//             <div className='mt-auto pt-3'>
-//                 <Link
-//                 to={'projects/${id}'}
-//                 onClick={(e) => e.stopPropagation()}
-//                 className='
-//                 inline-block
-//                 bg-indigo-500 dark:bg-indigo-600
-//                 text-white px-4 py-2 rounded-md
-//                 font-semibold hover:opacity-90 transition-opacity'
-//                 >
-//                     View Project Details
-//                 </Link>
-//             </div>
-//         )}
-//       </div>
-//     </div>
-//   );
-// };
-
-// export default AllProjectsItem;
-
-
-// //WORKING
-// import React, { useState } from 'react';
-// import { ProjectData } from '../data/projectData';
-// import { Link } from 'react-router-dom';
-
-// interface AllProjectsItemProps {
-//   project: ProjectData;
-// }
-
-// const AllProjectsItem: React.FC<AllProjectsItemProps> = ({ project }) => {
-//   // Make sure your project data includes an 'id' if you want to link internally
-//   const { id, title, shortDesc, longDesc, imageUrl, repoLink } = project;
-//   const [isExpanded, setIsExpanded] = useState(false);
-
-//   const handleCardClick = () => {
-//     setIsExpanded(!isExpanded);
-//   };
-
-//   return (
-//     <div
-//       onClick={handleCardClick}
-//       className="
-//         bg-white dark:bg-gray-800
-//         rounded-lg
-//         shadow-card 
-//         hover:shadow-card-hover
-//         transition-shadow
-//         cursor-pointer
-//         flex flex-col
-//         group
-//         transform transition-transform duration-200
-//         hover:-translate-y-1
-//       "
-//     >
-//       {/* Optional Image / Placeholder */}
-//       {imageUrl ? (
-//         <img
-//           src={imageUrl}
-//           alt={title}
-//           className="w-full h-40 object-cover rounded-t-lg"
-//         />
-//       ) : (
-//         <div className="w-full h-40 bg-gray-200 dark:bg-gray-700 flex items-center justify-center rounded-t-lg">
-//           <p className="text-gray-500 dark:text-gray-300">No Image</p>
-//         </div>
-//       )}
-
-//       {/* Card Content */}
-//       <div className="p-4 flex-1 flex flex-col">
-//         <h3
-//           className="
-//             text-xl font-bold mb-2
-//             text-gray-800 dark:text-gray-100
-//             group-hover:text-accent
-//             transition-colors
-//           "
-//         >
-//           {title}
-//         </h3>
-//         <p className="text-gray-600 dark:text-gray-300 line-clamp-2">
-//           {shortDesc}
-//         </p>
-
-//         {/* Expanded Details */}
-//         {isExpanded && (
-//           <div className="mt-3">
-//             {longDesc && (
-//               <>
-//                 <hr className="border-gray-300 dark:border-gray-600 mb-3" />
-//                 <p className="text-gray-700 dark:text-gray-300">{longDesc}</p>
-//               </>
-//             )}
-
-//             {/* Show either repo link OR internal project detail link */}
-//             <div className="mt-4">
-//               {repoLink ? (
-//                 <a
-//                   href={repoLink}
-//                   target="_blank"
-//                   rel="noopener noreferrer"
-//                   onClick={(e) => e.stopPropagation()} 
-//                   className="
-//                     inline-block
-//                     bg-indigo-500 dark:bg-indigo-600
-//                     text-white px-4 py-2 rounded-md
-//                     font-semibold hover:opacity-90 transition-opacity
-//                   "
-//                 >
-//                   View Full Details
-//                 </a>
-//               ) : (
-//                 <Link
-//                   to={`/projects/${id}`} 
-//                   onClick={(e) => e.stopPropagation()}
-//                   className="
-//                     inline-block
-//                     bg-indigo-500 dark:bg-indigo-600
-//                     text-white px-4 py-2 rounded-md
-//                     font-semibold hover:opacity-90 transition-opacity
-//                   "
-//                 >
-//                   View Project Details
-//                 </Link>
-//               )}
-//             </div>
-//           </div>
-//         )}
-//       </div>
-//     </div>
-//   );
-// };
-
-// export default AllProjectsItem;
-
-
-// src/components/AllProjectsItem.tsx
-import React, { useState } from 'react';
-import { ProjectData } from '../data/projectData';
+import React, { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
+
+import { ProjectData, ProjectAction } from '../data/projectData';
 
 interface AllProjectsItemProps {
   project: ProjectData;
 }
 
-const AllProjectsItem: React.FC<AllProjectsItemProps> = ({ project }) => {
-  const { id, title, shortDesc, longDesc, imageUrl, repoLink } = project;
-  const [isExpanded, setIsExpanded] = useState(false);
+const CTA_PRIMARY_CLASSES =
+  'inline-flex items-center justify-center rounded-md bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500';
+const CTA_SECONDARY_CLASSES =
+  'inline-flex items-center justify-center rounded-md border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-600 transition-colors hover:border-indigo-300 hover:text-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-indigo-700/60 dark:text-indigo-300 dark:hover:border-indigo-500 dark:hover:text-indigo-200';
 
-  const handleCardClick = () => {
-    setIsExpanded(!isExpanded);
+const AllProjectsItem: React.FC<AllProjectsItemProps> = ({ project }) => {
+  const {
+    id,
+    title,
+    shortDesc,
+    longDesc,
+    imageUrl,
+    techStack,
+    role,
+    impact,
+    actions,
+    repoLink,
+    impactMetrics,
+    features,
+    problem,
+  } = project;
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const detailsPanelId = useMemo(() => `project-${id}-details`, [id]);
+
+  const internalAction = actions?.find((action) => action.type === 'internal');
+  const externalActions = (actions ?? []).filter((action) => action.type !== 'internal');
+  const shouldRenderFooter = Boolean(internalAction || externalActions.length > 0 || repoLink);
+
+  const expandableSections = {
+    longDesc,
+    problem,
+    features,
+    impactMetrics,
+  };
+  const hasExpandableContent = Object.values(expandableSections).some((value) => {
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+    return Boolean(value);
+  });
+
+  const handleToggleDetails = () => {
+    if (!hasExpandableContent) return;
+    setIsExpanded((prev) => !prev);
   };
 
   return (
-    <motion.div
-      onClick={handleCardClick}
+    <motion.article
       layout
-      whileHover={{ scale: 1.03 }}
-      className="
-        bg-white dark:bg-gray-800
-        rounded-lg overflow-hidden
-        shadow-lg hover:shadow-2xl
-        transition-all duration-300
-        cursor-pointer
-      "
+      whileHover={{ scale: 1.02 }}
+      className="flex h-full flex-col overflow-hidden rounded-lg bg-white shadow-lg transition-shadow duration-300 hover:shadow-2xl dark:bg-gray-800"
     >
-      {/* Image Section */}
       {imageUrl ? (
-        <img
-          src={imageUrl}
-          alt={title}
-          className="w-full h-48 object-cover"
-        />
+        <img src={imageUrl} alt={title} className="h-48 w-full object-cover" />
       ) : (
-        <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-          <p className="text-gray-500 dark:text-gray-300">No Image</p>
+        <div className="flex h-48 w-full items-center justify-center bg-gray-100 text-sm text-gray-500 dark:bg-gray-700 dark:text-gray-300">
+          No Image Available
         </div>
       )}
 
-      {/* Content Section */}
-      <div className="p-6">
-        <h3 className="text-2xl font-semibold mb-2 text-gray-800 dark:text-gray-100">
-          {title}
-        </h3>
-        <p className="text-gray-600 dark:text-gray-300 line-clamp-3">
-          {shortDesc}
-        </p>
+      <div className="flex h-full flex-col">
+        <div className="flex flex-1 flex-col p-6">
+          <h3 className="text-2xl font-semibold text-gray-800 dark:text-gray-100">{title}</h3>
+          <p className="mt-2 text-gray-600 dark:text-gray-300">{shortDesc}</p>
 
-        <AnimatePresence>
-          {isExpanded && (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.3 }}
-              className="mt-4 overflow-hidden"
-              onClick={(e) => e.stopPropagation()} // Prevent card toggle when clicking inside expanded area
-            >
-              {longDesc && (
-                <>
-                  <hr className="border-gray-300 dark:border-gray-600 mb-3" />
-                  <p className="text-gray-700 dark:text-gray-300">{longDesc}</p>
-                </>
+          <div className="mt-4 flex-1">
+            <div className="flex min-h-[150px] flex-col gap-4">
+              {techStack && techStack.length > 0 && (
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    Tech Stack
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {techStack.map((tech) => (
+                      <span
+                        key={tech}
+                        className="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-200"
+                      >
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                </div>
               )}
 
-              <div className="mt-4 flex justify-end">
-                {repoLink ? (
-                  <a
-                    href={repoLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="
-                      bg-indigo-500 dark:bg-indigo-600
-                      text-white px-4 py-2 rounded-md
-                      font-semibold hover:bg-indigo-600 dark:hover:bg-indigo-700
-                      transition-colors
-                    "
-                  >
-                    View Full Details
-                  </a>
-                ) : (
-                  <Link
-                    to={`/projects/${id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="
-                      bg-indigo-500 dark:bg-indigo-600
-                      text-white px-4 py-2 rounded-md
-                      font-semibold hover:bg-indigo-600 dark:hover:bg-indigo-700
-                      transition-colors
-                    "
-                  >
-                    View Project Details
-                  </Link>
-                )}
-              </div>
-            </motion.div>
+              {role && (
+                <p className="text-sm text-gray-700 dark:text-gray-300">
+                  <span className="font-semibold text-gray-800 dark:text-gray-100">Role: </span>
+                  {role}
+                </p>
+              )}
+
+              {impact && (
+                <p className="text-sm text-gray-700 dark:text-gray-300">
+                  <span className="font-semibold text-gray-800 dark:text-gray-100">Impact: </span>
+                  {impact}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {hasExpandableContent && (
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={handleToggleDetails}
+                aria-expanded={isExpanded}
+                aria-controls={detailsPanelId}
+                className="inline-flex items-center gap-2 rounded-md border border-transparent px-4 py-2 text-sm font-semibold text-indigo-600 transition-colors hover:text-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:text-indigo-300 dark:hover:text-indigo-200"
+              >
+                {isExpanded ? 'Show less' : 'More details'}
+                <span aria-hidden="true">{isExpanded ? '−' : '+'}</span>
+              </button>
+            </div>
           )}
-        </AnimatePresence>
+
+          <AnimatePresence initial={false}>
+            {isExpanded && hasExpandableContent && (
+              <motion.section
+                id={detailsPanelId}
+                key="expanded-content"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.3 }}
+                className="mt-4 space-y-4 overflow-hidden text-sm text-gray-700 dark:text-gray-300"
+              >
+                {longDesc && <p>{longDesc}</p>}
+
+                {problem && (
+                  <div>
+                    <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-100">Problem</h4>
+                    <p className="mt-1">{problem}</p>
+                  </div>
+                )}
+
+                {features && features.length > 0 && (
+                  <div>
+                    <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-100">Key Features</h4>
+                    <ul className="mt-1 list-disc space-y-1 pl-5">
+                      {features.map((feature) => (
+                        <li key={feature}>{feature}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {impactMetrics && impactMetrics.length > 0 && (
+                  <div>
+                    <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-100">Impact Metrics</h4>
+                    <ul className="mt-1 list-disc space-y-1 pl-5">
+                      {impactMetrics.map((metric) => (
+                        <li key={metric}>{metric}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </motion.section>
+            )}
+          </AnimatePresence>
+        </div>
+
+        {shouldRenderFooter && (
+          <div className="flex flex-wrap gap-3 border-t border-gray-200 px-6 py-4 dark:border-gray-700">
+            {internalAction && (
+              <Link to={internalAction.href} className={CTA_PRIMARY_CLASSES}>
+                {internalAction.label}
+              </Link>
+            )}
+
+            {externalActions.map((action: ProjectAction) => (
+              <a
+                key={action.href}
+                href={action.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={internalAction ? CTA_SECONDARY_CLASSES : CTA_PRIMARY_CLASSES}
+              >
+                {action.label}
+              </a>
+            ))}
+
+            {!actions?.length && repoLink && (
+              <a
+                href={repoLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={CTA_PRIMARY_CLASSES}
+              >
+                View Repo
+              </a>
+            )}
+          </div>
+        )}
       </div>
-    </motion.div>
+    </motion.article>
   );
 };
 


### PR DESCRIPTION
## Summary
- replace the card-level toggle with a dedicated accessible “More details” control and persistent metadata layout
- keep tech stack, role, and impact visible while collapsed and relocate action buttons to a fixed footer
- ensure expandable copy remains available with keyboard support and updated CTA handling for internal/external links

## Why
- the portfolio grid needed consistent card heights and better accessibility for keyboard and assistive technology users

## Risk/Impact
- Low: UI restructuring of the project card component

## Testing
- npm run build

------
